### PR TITLE
socket_send freezes with some requests

### DIFF
--- a/MinecraftServerStatus/status.class.php
+++ b/MinecraftServerStatus/status.class.php
@@ -43,6 +43,7 @@
 
                 socket_send($socket, $handshake, strlen($handshake), 0); //give the server a high five
                 socket_send($socket, "\x01\x00", 2, 0);
+                usleep(500);
                 socket_read( $socket, 1 );
 
                 $ping = round((microtime(true)-$start)*1000); //calculate the high five duration


### PR DESCRIPTION
Checking 200+ servers in parallel with pcntl_fork only one child process freezes (randomly) at socket_send.
